### PR TITLE
Add GitHub Skills activity (Issue #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This pull request addresses Issue #6 - the missing GitHub Skills activity that was announced by the principal.

## Changes Made
- Added the "GitHub Skills" activity to the activities list in `src/app.py`
- Activity details include:
  - Description linking to the GitHub Certifications program
  - Schedule: Wednesdays, 3:30 PM - 4:30 PM
  - Capacity: 25 participants
  - Initially available with no registrations

## Related Issue
Closes #6 - Missing Activity: GitHub Skills

## Testing
Students can now:
- View the GitHub Skills activity in the list of available activities
- Register for the GitHub Skills activity through the signup form